### PR TITLE
Fix PropTypes import

### DIFF
--- a/src/Counter.js
+++ b/src/Counter.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Text } from 'react-native';
 import eases from 'eases';
 


### PR DESCRIPTION
From version 15.5.0 of react PropTypes has moved into an external package 'prop-types'.
(https://reactjs.org/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes)