### PR TITLE
Added reset & fix memory leak when unmount parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,22 @@ import Counter from 'react-native-counter';
 />
 ```
 
+# Reset from parent view
+
+```javascript
+import Counter from 'react-native-counter';
+
+<Counter
+ ...
+ ref={counter => this.counter = counter}
+/>
+
+  // Example method restarting the counter
+  resetCounter() {
+    this.counter.reset();
+  }
+```
+
 The easing prop is a string corresponding to one of any function from [eases](https://github.com/mattdesl/eases).
 
 # License

--- a/src/Counter.js
+++ b/src/Counter.js
@@ -26,9 +26,22 @@ export default class Counter extends Component {
   componentDidMount() {
     this.startTime = Date.now();
     requestAnimationFrame(this.animate.bind(this));
+    this.umount = false
+  }
+
+  componentWillUnmount() {
+    this.umount = true
+  }
+
+  reset() {
+      this.startTime = Date.now();
+      this.stop = false
+      requestAnimationFrame(this.animate.bind(this));
   }
 
   animate() {
+    if(this.umount) return;
+    
     const { onComplete } = this.props;
 
     if (this.stop) {

--- a/src/Counter.js
+++ b/src/Counter.js
@@ -25,8 +25,8 @@ export default class Counter extends Component {
 
   componentDidMount() {
     this.startTime = Date.now();
-    requestAnimationFrame(this.animate.bind(this));
     this.umount = false
+    requestAnimationFrame(this.animate.bind(this));
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
Counter.js
- added method: [reset] to reset the counter again to start.
- added method: [componentWillUnmount] to stop the counter and fix memory leak when Unmount parent view or change view in react-native-router-flux.
- updated method: [animate] for stop the loop when the componentWillUnmount was executed.

Readme.md
- added example to call reset from parent view.